### PR TITLE
Update serving-default-domain.yaml

### DIFF
--- a/Google/anthos-gke/serving-default-domain.yaml
+++ b/Google/anthos-gke/serving-default-domain.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     app: "default-domain"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v1.10.6"
 spec:
   template:
     metadata:
@@ -64,7 +64,7 @@ metadata:
   namespace: knative-serving
   labels:
     app: default-domain
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v1.10.6"
 spec:
   selector:
     app: default-domain


### PR DESCRIPTION
updating Knative to latest version (v1.10.6)